### PR TITLE
fixes #4: guava dep removed, using java7 methods instead

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
 
     <properties>
         <!--General stuff-->
-        <targetJdk>1.6</targetJdk>
+        <targetJdk>1.7</targetJdk>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     </properties>
@@ -59,11 +59,6 @@
             <artifactId>jaxb-xjc</artifactId>
             <version>2.0</version>
             <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>com.google.guava</groupId>
-            <artifactId>guava</artifactId>
-            <version>13.0</version>
         </dependency>
         <dependency>
             <groupId>junit</groupId>
@@ -211,8 +206,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.2</version>
                 <configuration>
-                    <source>1.6</source>
-                    <target>1.6</target>
+                    <source>${targetJdk}</source>
+                    <target>${targetJdk}</target>
                 </configuration>
             </plugin>
             <plugin>


### PR DESCRIPTION
Hi

(beforehand: I don't have the time at the moment to fork and rename the project (is this even possible at github?) and setup all the stuff to push to maven central, therefore I'm sharing this solution as a pull request; perhaps you need the plugin again some time in the future :) )

This pull request is an alternative solution to #8 without increasing the Guava version (because it removes Guava altogether).
Java is updated from 6 to 7, but I guess this is OK.

This change implements the suggestions from #4 with minimal changes:
- building equals using java.util.Objects.deepEquals(...)
  - this change replaces the array-detection (#5) because deepEquals also works for arrays
- building hashCode using java.util.Objects.hash(...)
- building toString using string concatenation
  - it avoids Guava version conflicts (MoreObjects requires Guava 18) and is easy to read

I also added a merge method for the collections, to avoid code duplication.
